### PR TITLE
Wp55 update checks

### DIFF
--- a/docs/bb-theme/customizer-settings/general.md
+++ b/docs/bb-theme/customizer-settings/general.md
@@ -101,7 +101,7 @@ The hover color sets the color of linked text and buttons when the cursor hovers
 
 ## Headings
 
-You can set heading styles that serve as the defaults in the Beaver Builder plugin (including Beaver Themer) and WordPress block editor layouts. Heading size can be configured responsively, in other words you can have different font sizes for large, medium, and small devices. See [this article about responsive default heading styles](/bb-theme/defaults-for-styles/typography/set-responsive-default-text-styles-for-beaver-builder-layouts.md) and [this article about system fonts](/bb-theme/defaults-for-styles/typography/customizer-font-family-setting-system-ui.md).
+You can set heading styles that serve as the defaults in the Beaver Builder plugin (including Beaver Themer) and Gutenberg layouts. Heading size can be configured responsively, in other words you can have different font sizes for large, medium, and small devices. See [this article about responsive default heading styles](/bb-theme/defaults-for-styles/typography/set-responsive-default-text-styles-for-beaver-builder-layouts.md) and [this article about system fonts](/bb-theme/defaults-for-styles/typography/customizer-font-family-setting-system-ui.md).
 
 ## Text
 

--- a/docs/bb-theme/customizer-settings/general.md
+++ b/docs/bb-theme/customizer-settings/general.md
@@ -101,7 +101,7 @@ The hover color sets the color of linked text and buttons when the cursor hovers
 
 ## Headings
 
-You can set heading styles that serve as the defaults in the Beaver Builder plugin (including Beaver Themer) and Gutenberg layouts. Heading size can be configured responsively, in other words you can have different font sizes for large, medium, and small devices. See [this article about responsive default heading styles](/bb-theme/defaults-for-styles/typography/set-responsive-default-text-styles-for-beaver-builder-layouts.md) and [this article about system fonts](/bb-theme/defaults-for-styles/typography/customizer-font-family-setting-system-ui.md).
+You can set heading styles that serve as the defaults in the Beaver Builder plugin (including Beaver Themer) and WordPress block editor layouts. Heading size can be configured responsively, in other words you can have different font sizes for large, medium, and small devices. See [this article about responsive default heading styles](/bb-theme/defaults-for-styles/typography/set-responsive-default-text-styles-for-beaver-builder-layouts.md) and [this article about system fonts](/bb-theme/defaults-for-styles/typography/customizer-font-family-setting-system-ui.md).
 
 ## Text
 

--- a/docs/bb-theme/defaults-for-styles/typography/set-responsive-default-text-styles-for-beaver-builder-layouts.md
+++ b/docs/bb-theme/defaults-for-styles/typography/set-responsive-default-text-styles-for-beaver-builder-layouts.md
@@ -9,7 +9,7 @@ In the Beaver Builder Theme, you can set responsive heading and text styles that
 :::tip **Tips**
   * The default settings that appear on this tab come from the theme preset, which is set in **Customize > Presets**.  
   Click the circular arrow icon to the right of a field to return to the default setting.
-  * These default settings also apply as defaults to headings and text in WordPress block editor layouts, though they will not display until you preview or view the page.
+  * These default settings also apply as defaults to headings and text in Gutenberg layouts, though they will not display until you preview or view the page.
 :::
 
 ## Set default heading styles

--- a/docs/bb-theme/defaults-for-styles/typography/set-responsive-default-text-styles-for-beaver-builder-layouts.md
+++ b/docs/bb-theme/defaults-for-styles/typography/set-responsive-default-text-styles-for-beaver-builder-layouts.md
@@ -9,7 +9,7 @@ In the Beaver Builder Theme, you can set responsive heading and text styles that
 :::tip **Tips**
   * The default settings that appear on this tab come from the theme preset, which is set in **Customize > Presets**.  
   Click the circular arrow icon to the right of a field to return to the default setting.
-  * These default settings also apply as defaults to headings and text in Gutenberg layouts, though they will not display until you preview or view the page.
+  * These default settings also apply as defaults to headings and text in WordPress block editor layouts, though they will not display until you preview or view the page.
 :::
 
 ## Set default heading styles

--- a/docs/bb-theme/getting-started/install-the-bb-theme-and-child-theme.md
+++ b/docs/bb-theme/getting-started/install-the-bb-theme-and-child-theme.md
@@ -4,7 +4,11 @@ title: Install the BB theme and child theme
 sidebar_label: Install the BB theme and child theme
 ---
 
-The [Beaver Builder Theme](https://www.wpbeaverbuilder.com/wordpress-framework-theme/) isn't required for the [Beaver Builder Plugin](https://www.wpbeaverbuilder.com), and not all premium versions of Beaver Builder include it, but it's a great framework theme with clean code and lots of options that are set in the WordPress Customizer.
+The [Beaver Builder Theme](https://www.wpbeaverbuilder.com/wordpress-framework-theme/) isn't required for the [Beaver Builder Plugin](https://www.wpbeaverbuilder.com) but it's a great framework theme with clean code and lots of options that are set in the WordPress Customizer.
+
+:::tip **Tip**
+You can check whether your Beaver Builder version includes the theme on the [Beaver Builder pricing page](https://www.wpbeaverbuilder.com/pricing/). If you want to add the Theme, it's easy to [upgrade to a different premium version](/general/account-billing/upgrade-your-premium-license.md).
+:::
 
 ## Should I use the Beaver Builder child theme?
 

--- a/docs/bb-theme/getting-started/install-the-bb-theme-and-child-theme.md
+++ b/docs/bb-theme/getting-started/install-the-bb-theme-and-child-theme.md
@@ -4,11 +4,7 @@ title: Install the BB theme and child theme
 sidebar_label: Install the BB theme and child theme
 ---
 
-The [Beaver Builder Theme](https://www.wpbeaverbuilder.com/wordpress-framework-theme/) isn't required for the [Beaver Builder Plugin](https://www.wpbeaverbuilder.com) but it's a great framework theme with clean code and lots of options that are set in the WordPress Customizer.
-
-:::tip **Tip**
-You can check whether your Beaver Builder version includes the theme on the [Beaver Builder pricing page](https://www.wpbeaverbuilder.com/pricing/). If you want to add the Theme, it's easy to [upgrade to a different premium version](/general/account-billing/upgrade-your-premium-license.md).
-:::
+The [Beaver Builder Theme](https://www.wpbeaverbuilder.com/wordpress-framework-theme/) isn't required for the [Beaver Builder Plugin](https://www.wpbeaverbuilder.com), and not all premium versions of Beaver Builder include it, but it's a great framework theme with clean code and lots of options that are set in the WordPress Customizer.
 
 ## Should I use the Beaver Builder child theme?
 

--- a/docs/beaver-builder/getting-started/bb-editor-basics/launch-builder.md
+++ b/docs/beaver-builder/getting-started/bb-editor-basics/launch-builder.md
@@ -4,39 +4,50 @@ title: Launch the Beaver Builder editor
 sidebar_label: Launch the Beaver Builder editor
 ---
 
-WordPress 5 uses the block editor (also called the Standard
-Editor or Gutenberg editor) by default. If you want to use the Classic Editor, in other words the WordPress editor that existed before the block editor, you have to install a plugin to restore it. This article contains
+WordPress 5 uses the new block editor (also called the Standard
+Editor or Gutenberg editor) by default. You can still use the Classic Editor, which is what used
+to just be called _the_ WordPress editor. As of WordPress 5, if you wish to
+continue to use the Classic Editor, you must install it as a
+[plugin](https://wordpress.org/plugins/classic-editor/). This article contains
 the instructions for accessing the Beaver Builder editor from both the
 WordPress block editor and the classic editor UI, and from other locations in
 the WordPress admin panel or admin bar.
 
 :::note **Note**
-We've found
-that both the [Classic Editor]((https://wordpress.org/plugins/classic-editor/)) and the [Disable Gutenberg](https://wordpress.org/plugins/disable-gutenberg/) plugins work with Beaver Builder. Most of the other plugins are untested but would be expected to work. If you are using a third-party plugin to restore the classic editor and have a problem, please file a Beaver Builder Support ticket so that we can document the problem and any possible workarounds, or list it as incompatible.
+There is an increasing number of third-party (not from Automattic)
+classic editor plugins. If you want to disable Gutenberg entirely, we've found
+that both of the Disable Gutenberg plugins work with Beaver Builder. Most of
+the other plugins have been untested with Beaver Builder. If you are using a
+third-party plugin to restore the classic editor and have a problem not
+described here, please file a Beaver Builder Support ticket so that we can
+document the problem and any possible workarounds, or list it as incompatible.
 :::
 
 :::note **Note**
-By default, the Beaver Builder editor is enabled for page layouts only. You can [enable posts and custom post types in the Beaver Builder settings](/beaver-builder/management-migration/control-which-post-types-can-use-beaver-builder.md).
+If you want to edit a Post layout in Beaver Builder, you need to
+[enable Posts as a post type in the Beaver Builder settings](/beaver-builder/management-migration/control-which-post-types-can-use-beaver-builder.md).
 :::
 
 ## 1\. From the WordPress editing page (block or classic)
 
-### 1.1 From the WordPress Block Editor
+### 1.1 In the Block Editor (Gutenberg) UI
 
 When you create a page or open an existing page in the WordPress block editor,
-you'll see the choice of **Launch Beaver Builder** or Use Standard Editor, as shown in the following screenshot.
+you'll see a choice to either launch Beaver Builder or use the Standard
+(Gutenberg) editor, as shown in the following screenshot.
 
 ![](/img/the-basics-open-builder-editor-1.png)
 
 ### 1.2 In the Classic Editor UI
 
-Create a new page  and click the **Beaver Builder** tab or open an existing page for editing in WordPress and click **Launch Beaver Builder** on the **Beaver Builder** tab, as in the following screenshot.
+Create a new page or open an existing page for editing in WordPress and click
+the **Beaver Builder** tab, as in the following screenshot.
 
 ![](/img/the-basics-open-builder-editor-2.png)
 
 :::note **Note**
-If you're using the Classic Editor plugin and don't see the **Beaver Builder** tab, one way to make it
-appear is to force the use of Classic editor rather than the WordPress block editor.
+If you don't see the **Beaver Builder** tab, one way to make it
+appear is to force the use of Classic editor rather than the Gutenberg editor.
 On the WordPress admin panel, go to **Settings > Writing** and select **No**
 for **Allow users to switch editors**. If you want users to continue to have a
 choice of WordPress editor for each page or post they create, use any of the
@@ -45,7 +56,8 @@ other methods described here to open the Beaver Builder editor.
 
 ## 2 From the **All Pages** list
 
-Mouse over a page in the **Pages > All Pages** list, then click the **Beaver Builder** link.
+Mouse over a page in the **Pages > All Pages** list, then click the **Beaver
+Builder** link.
 
 ![](/img/the-basics-open-builder-editor-3.png)
 

--- a/docs/beaver-builder/getting-started/bb-editor-basics/launch-builder.md
+++ b/docs/beaver-builder/getting-started/bb-editor-basics/launch-builder.md
@@ -4,50 +4,39 @@ title: Launch the Beaver Builder editor
 sidebar_label: Launch the Beaver Builder editor
 ---
 
-WordPress 5 uses the new block editor (also called the Standard
-Editor or Gutenberg editor) by default. You can still use the Classic Editor, which is what used
-to just be called _the_ WordPress editor. As of WordPress 5, if you wish to
-continue to use the Classic Editor, you must install it as a
-[plugin](https://wordpress.org/plugins/classic-editor/). This article contains
+WordPress 5 uses the block editor (also called the Standard
+Editor or Gutenberg editor) by default. If you want to use the Classic Editor, in other words the WordPress editor that existed before the block editor, you have to install a plugin to restore it. This article contains
 the instructions for accessing the Beaver Builder editor from both the
 WordPress block editor and the classic editor UI, and from other locations in
 the WordPress admin panel or admin bar.
 
 :::note **Note**
-There is an increasing number of third-party (not from Automattic)
-classic editor plugins. If you want to disable Gutenberg entirely, we've found
-that both of the Disable Gutenberg plugins work with Beaver Builder. Most of
-the other plugins have been untested with Beaver Builder. If you are using a
-third-party plugin to restore the classic editor and have a problem not
-described here, please file a Beaver Builder Support ticket so that we can
-document the problem and any possible workarounds, or list it as incompatible.
+We've found
+that both the [Classic Editor]((https://wordpress.org/plugins/classic-editor/)) and the [Disable Gutenberg](https://wordpress.org/plugins/disable-gutenberg/) plugins work with Beaver Builder. Most of the other plugins are untested but would be expected to work. If you are using a third-party plugin to restore the classic editor and have a problem, please file a Beaver Builder Support ticket so that we can document the problem and any possible workarounds, or list it as incompatible.
 :::
 
 :::note **Note**
-If you want to edit a Post layout in Beaver Builder, you need to
-[enable Posts as a post type in the Beaver Builder settings](/beaver-builder/management-migration/control-which-post-types-can-use-beaver-builder.md).
+By default, the Beaver Builder editor is enabled for page layouts only. You can [enable posts and custom post types in the Beaver Builder settings](/beaver-builder/management-migration/control-which-post-types-can-use-beaver-builder.md).
 :::
 
 ## 1\. From the WordPress editing page (block or classic)
 
-### 1.1 In the Block Editor (Gutenberg) UI
+### 1.1 From the WordPress Block Editor
 
 When you create a page or open an existing page in the WordPress block editor,
-you'll see a choice to either launch Beaver Builder or use the Standard
-(Gutenberg) editor, as shown in the following screenshot.
+you'll see the choice of **Launch Beaver Builder** or Use Standard Editor, as shown in the following screenshot.
 
 ![](/img/the-basics-open-builder-editor-1.png)
 
 ### 1.2 In the Classic Editor UI
 
-Create a new page or open an existing page for editing in WordPress and click
-the **Beaver Builder** tab, as in the following screenshot.
+Create a new page  and click the **Beaver Builder** tab or open an existing page for editing in WordPress and click **Launch Beaver Builder** on the **Beaver Builder** tab, as in the following screenshot.
 
 ![](/img/the-basics-open-builder-editor-2.png)
 
 :::note **Note**
-If you don't see the **Beaver Builder** tab, one way to make it
-appear is to force the use of Classic editor rather than the Gutenberg editor.
+If you're using the Classic Editor plugin and don't see the **Beaver Builder** tab, one way to make it
+appear is to force the use of Classic editor rather than the WordPress block editor.
 On the WordPress admin panel, go to **Settings > Writing** and select **No**
 for **Allow users to switch editors**. If you want users to continue to have a
 choice of WordPress editor for each page or post they create, use any of the
@@ -56,8 +45,7 @@ other methods described here to open the Beaver Builder editor.
 
 ## 2 From the **All Pages** list
 
-Mouse over a page in the **Pages > All Pages** list, then click the **Beaver
-Builder** link.
+Mouse over a page in the **Pages > All Pages** list, then click the **Beaver Builder** link.
 
 ![](/img/the-basics-open-builder-editor-3.png)
 

--- a/docs/beaver-builder/getting-started/bb-editor-basics/launch-builder.md
+++ b/docs/beaver-builder/getting-started/bb-editor-basics/launch-builder.md
@@ -43,7 +43,7 @@ choice of WordPress editor for each page or post they create, use any of the
 other methods described here to open the Beaver Builder editor.
 :::
 
-## 2 From the **All Pages** list
+## 2 From the All Pages list
 
 Mouse over a page in the **Pages > All Pages** list, then click the **Beaver Builder** link.
 

--- a/docs/beaver-builder/getting-started/bb-editor-basics/launch-builder.md
+++ b/docs/beaver-builder/getting-started/bb-editor-basics/launch-builder.md
@@ -12,7 +12,7 @@ the WordPress admin panel or admin bar.
 
 :::note **Note**
 We've found
-that both the [Classic Editor]((https://wordpress.org/plugins/classic-editor/)) and the [Disable Gutenberg](https://wordpress.org/plugins/disable-gutenberg/) plugins work with Beaver Builder. Most of the other plugins are untested but would be expected to work. If you are using a third-party plugin to restore the classic editor and have a problem, please file a Beaver Builder Support ticket so that we can document the problem and any possible workarounds, or list it as incompatible.
+that both the [Classic Editor](https://wordpress.org/plugins/classic-editor/) and the [Disable Gutenberg](https://wordpress.org/plugins/disable-gutenberg/) plugins work with Beaver Builder. Most of the other plugins are untested but would be expected to work. If you are using a third-party plugin to restore the classic editor and have a problem, please file a Beaver Builder Support ticket so that we can document the problem and any possible workarounds, or list it as incompatible.
 :::
 
 :::note **Note**

--- a/docs/beaver-builder/getting-started/what-can-i-do-with-beaver-builder.md
+++ b/docs/beaver-builder/getting-started/what-can-i-do-with-beaver-builder.md
@@ -45,13 +45,13 @@ this example:
 
 ### Start with a layout template, prebuilt rows, or a blank page
 
-When you create a new WordPress Page, you'll see the Beaver Builder launch
-button on posts and pages for which the WordPress Standard (block) editor is enabled:
+When you create a new WordPress Page, you'll see theBeaver Builder launch
+button on posts and pages for which the WordPress Gutenberg editor is enabled:
 
 ![](/img/what-can-i-do-with-beaverbuilder-3.png)
 
 Or you'll see the **Beaver Builder** tab on posts and pages for which the
-WordPress Standard editor is disabled:
+WordPress Gutenberg editor is disabled:
 
 ![](/img/what-can-i-do-with-beaverbuilder-4.png)
 

--- a/docs/beaver-builder/getting-started/what-can-i-do-with-beaver-builder.md
+++ b/docs/beaver-builder/getting-started/what-can-i-do-with-beaver-builder.md
@@ -45,13 +45,13 @@ this example:
 
 ### Start with a layout template, prebuilt rows, or a blank page
 
-When you create a new WordPress Page, you'll see theBeaver Builder launch
-button on posts and pages for which the WordPress Gutenberg editor is enabled:
+When you create a new WordPress Page, you'll see the Beaver Builder launch
+button on posts and pages for which the WordPress Standard (block) editor is enabled:
 
 ![](/img/what-can-i-do-with-beaverbuilder-3.png)
 
 Or you'll see the **Beaver Builder** tab on posts and pages for which the
-WordPress Gutenberg editor is disabled:
+WordPress Standard editor is disabled:
 
 ![](/img/what-can-i-do-with-beaverbuilder-4.png)
 

--- a/docs/beaver-builder/management-migration/change-wordpress-screen-options.md
+++ b/docs/beaver-builder/management-migration/change-wordpress-screen-options.md
@@ -6,13 +6,13 @@ sidebar_label: Change WordPress screen options
 
 WordPress has screen options for editing single pages and posts that may be
 turned off by default, such as excerpts for posts and custom fields. These
-options appear on the standard WordPress editing pages with the Standard (block) Editor or
+options appear on the standard WordPress editing pages with the Gutenberg or
 Classic editor.
 
 To check and modify your screen options, use the following instructions
-depending on whether you use the Standard or Classic WordPress editor.
+depending on whether you use Gutenberg or the classic WordPress editor.
 
-**To change screen options in the WordPress Standard Editor:**
+**To change screen options in the Gutenberg UI:**
 
 Follow the animation below or use this procedure.
 

--- a/docs/beaver-builder/management-migration/change-wordpress-screen-options.md
+++ b/docs/beaver-builder/management-migration/change-wordpress-screen-options.md
@@ -6,13 +6,13 @@ sidebar_label: Change WordPress screen options
 
 WordPress has screen options for editing single pages and posts that may be
 turned off by default, such as excerpts for posts and custom fields. These
-options appear on the standard WordPress editing pages with the Gutenberg or
+options appear on the standard WordPress editing pages with the Standard (block) Editor or
 Classic editor.
 
 To check and modify your screen options, use the following instructions
-depending on whether you use Gutenberg or the classic WordPress editor.
+depending on whether you use the Standard or Classic WordPress editor.
 
-**To change screen options in the Gutenberg UI:**
+**To change screen options in the WordPress Standard Editor:**
 
 Follow the animation below or use this procedure.
 

--- a/docs/beaver-builder/management-migration/convert-content-between-wordpress-5-and-beaver-builder.md
+++ b/docs/beaver-builder/management-migration/convert-content-between-wordpress-5-and-beaver-builder.md
@@ -1,10 +1,10 @@
 ---
 id: convert-content-between-wordpress-5-and-beaver-builder
-title: Convert content between WordPress 5 and Beaver Builder
-sidebar_label: Convert content between WordPress 5 and Beaver Builder
+title: Convert content between WordPress and Beaver Builder
+sidebar_label: Convert content between WordPress and Beaver Builder
 ---
 
-This article applies to how to convert content from the Gutenberg or Classic
+This article applies to how to convert content from the Standard (block) or Classic
 editor in WordPress 5 to Beaver Builder and vice versa. It also describes the
 result of each type of conversion. [Follow this link](/beaver-builder/getting-started/bb-editor-basics/launch-builder.md) for how to install the Classic Editor plugin and how to
 open the Beaver Builder editor in WordPress 5.
@@ -15,10 +15,10 @@ You can start editing a new page in either WordPress editor
 of switching back and forth after that--you may lose data.
 
 If you open a Beaver Builder layout in the Standard or Classic editor and
-make further edits, and then you convert back to Beaver Builder, you will see
+make further edits, and then you convert back to Beaver Builder, you'll see
 your previous Beaver Builder layout. You won't see the new WordPress edits
 that you made. If you publish the Beaver Builder layout and open the page
-again in Standard or Classic Editor, you will lose the previous edits that you
+again in Standard or Classic Editor, you'll lose the previous edits that you
 made in the Standard or Classic Editor.
 :::
 
@@ -28,16 +28,15 @@ types**, you will only see the option to launch Beaver Builder for Pages, not
 Posts.
 :::
 
-## Convert content from Standard Editor (Gutenberg) to Beaver Builder
+## Convert content from the Standard (block) Editor to Beaver Builder
 
-This section applies when a page has content created with the WordPress 5
+This section applies when a page has content created with the WordPress
 Standard (block) Editor and you want to convert that content to Beaver
 Builder. You can use [any of the methods for opening a page in Beaver
-Builder](/beaver-builder/getting-started/bb-editor-basics/launch-builder.md), or you can convert directly from within the Standard
-Editor UI, as follows. No matter what method you use to open Beaver Builder,
-the content is automatically converted. Pay attention to the warning below.
+Builder](/beaver-builder/getting-started/bb-editor-basics/launch-builder.md), or you can convert directly from within the Standard Editor, as follows. No matter what method you use to open Beaver Builder,
+the content is automatically converted. Pay attention to the warning above.
 
-**Convert content to Beaver Builder from within the Standard Editor UI:**
+**Convert content to Beaver Builder from within the WordPress Standard Editor:**
 
   1. Click the **More** icon (three vertical dots) in the upper right corner of the standard edit screen.
   2. In the **Plugins** section, choose **Convert to Beaver Builder**, as shown in the following screenshot.
@@ -47,7 +46,7 @@ the content is automatically converted. Pay attention to the warning below.
 **Result:** The block content is converted to a single Beaver Builder Text
 Editor module.
 
-## Convert content from Classic Editor to Beaver Builder
+## Convert content from the Classic Editor to Beaver Builder
 
 This section applies when you have the Classic Editor plugin activated and
 allow it to be used in **Settings > Writing**, and you have a page or post of
@@ -65,19 +64,20 @@ Builder.
 **Result:** The Classic Editor text and images are converted to a single Text
 Editor module in Beaver Builder.
 
-## Convert content from Beaver Builder to Standard Editor (Gutenberg)
+## Convert content from Beaver Builder to the Standard (block) Editor
 
 This section applies when you have a page or post with Beaver Builder content
-that you want to convert to the Standard (Gutenberg Block) Editor.
+that you want to convert to the Standard (block) Editor.
 
   1. From the WordPress admin panel, choose **Pages > All Pages**.
   2. Mouse over the page that you want to convert to reveal the choices.  
 The dot following the Beaver Builder link will be green, showing that the
 layout is currently in Beaver Builder.
 
-  3. Click either **Edit** or **Block Editor**, depending on your editor settings in **Settings > Writing**.
+  3. Click either **Edit** or **Block Editor**, depending on your editor settings in **Settings > Writing**.  
+  If you have the Classic Editor installed, then click either **Edit** or **Block Editor**, depending on your editor settings in **Settings > Writing**.
 
- **Result:** Opening a Beaver Builder layout in Standard Editor (Gutenberg)
+ **Result:** Opening a Beaver Builder layout in the Standard Editor
 converts the layout into a single Classic block. From there, you can select
 the option to convert the item to blocks (available from the **More options**
 menu in the block's toolbar), as shown in the following screenshot.
@@ -96,7 +96,8 @@ This ensures that there is an existing Beaver Builder layout for this page. If
 there is no existing Beaver Builder layout, the dot is light gray or white.  
 ![](/img/the-basics-convert-content-4.png)
 
-  3. Click either **Edit** or **Classic Editor**, depending on your WordPress settings.
+  3. Click **Edit**.  
+  If you have the Classic Editor installed, then click either **Edit** or **Classic Editor**, depending on your settings in **Settings > Writing**.
 
  **Result:** The text and images are converted from Beaver Builder to Classic
 Editor.

--- a/docs/beaver-builder/management-migration/convert-content-between-wordpress-5-and-beaver-builder.md
+++ b/docs/beaver-builder/management-migration/convert-content-between-wordpress-5-and-beaver-builder.md
@@ -1,10 +1,10 @@
 ---
 id: convert-content-between-wordpress-5-and-beaver-builder
-title: Convert content between WordPress and Beaver Builder
-sidebar_label: Convert content between WordPress and Beaver Builder
+title: Convert content between WordPress 5 and Beaver Builder
+sidebar_label: Convert content between WordPress 5 and Beaver Builder
 ---
 
-This article applies to how to convert content from the Standard (block) or Classic
+This article applies to how to convert content from the Gutenberg or Classic
 editor in WordPress 5 to Beaver Builder and vice versa. It also describes the
 result of each type of conversion. [Follow this link](/beaver-builder/getting-started/bb-editor-basics/launch-builder.md) for how to install the Classic Editor plugin and how to
 open the Beaver Builder editor in WordPress 5.
@@ -15,10 +15,10 @@ You can start editing a new page in either WordPress editor
 of switching back and forth after that--you may lose data.
 
 If you open a Beaver Builder layout in the Standard or Classic editor and
-make further edits, and then you convert back to Beaver Builder, you'll see
+make further edits, and then you convert back to Beaver Builder, you will see
 your previous Beaver Builder layout. You won't see the new WordPress edits
 that you made. If you publish the Beaver Builder layout and open the page
-again in Standard or Classic Editor, you'll lose the previous edits that you
+again in Standard or Classic Editor, you will lose the previous edits that you
 made in the Standard or Classic Editor.
 :::
 
@@ -28,15 +28,16 @@ types**, you will only see the option to launch Beaver Builder for Pages, not
 Posts.
 :::
 
-## Convert content from the Standard (block) Editor to Beaver Builder
+## Convert content from Standard Editor (Gutenberg) to Beaver Builder
 
-This section applies when a page has content created with the WordPress
+This section applies when a page has content created with the WordPress 5
 Standard (block) Editor and you want to convert that content to Beaver
 Builder. You can use [any of the methods for opening a page in Beaver
-Builder](/beaver-builder/getting-started/bb-editor-basics/launch-builder.md), or you can convert directly from within the Standard Editor, as follows. No matter what method you use to open Beaver Builder,
-the content is automatically converted. Pay attention to the warning above.
+Builder](/beaver-builder/getting-started/bb-editor-basics/launch-builder.md), or you can convert directly from within the Standard
+Editor UI, as follows. No matter what method you use to open Beaver Builder,
+the content is automatically converted. Pay attention to the warning below.
 
-**Convert content to Beaver Builder from within the WordPress Standard Editor:**
+**Convert content to Beaver Builder from within the Standard Editor UI:**
 
   1. Click the **More** icon (three vertical dots) in the upper right corner of the standard edit screen.
   2. In the **Plugins** section, choose **Convert to Beaver Builder**, as shown in the following screenshot.
@@ -46,7 +47,7 @@ the content is automatically converted. Pay attention to the warning above.
 **Result:** The block content is converted to a single Beaver Builder Text
 Editor module.
 
-## Convert content from the Classic Editor to Beaver Builder
+## Convert content from Classic Editor to Beaver Builder
 
 This section applies when you have the Classic Editor plugin activated and
 allow it to be used in **Settings > Writing**, and you have a page or post of
@@ -64,20 +65,19 @@ Builder.
 **Result:** The Classic Editor text and images are converted to a single Text
 Editor module in Beaver Builder.
 
-## Convert content from Beaver Builder to the Standard (block) Editor
+## Convert content from Beaver Builder to Standard Editor (Gutenberg)
 
 This section applies when you have a page or post with Beaver Builder content
-that you want to convert to the Standard (block) Editor.
+that you want to convert to the Standard (Gutenberg Block) Editor.
 
   1. From the WordPress admin panel, choose **Pages > All Pages**.
   2. Mouse over the page that you want to convert to reveal the choices.  
 The dot following the Beaver Builder link will be green, showing that the
 layout is currently in Beaver Builder.
 
-  3. Click either **Edit** or **Block Editor**, depending on your editor settings in **Settings > Writing**.  
-  If you have the Classic Editor installed, then click either **Edit** or **Block Editor**, depending on your editor settings in **Settings > Writing**.
+  3. Click either **Edit** or **Block Editor**, depending on your editor settings in **Settings > Writing**.
 
- **Result:** Opening a Beaver Builder layout in the Standard Editor
+ **Result:** Opening a Beaver Builder layout in Standard Editor (Gutenberg)
 converts the layout into a single Classic block. From there, you can select
 the option to convert the item to blocks (available from the **More options**
 menu in the block's toolbar), as shown in the following screenshot.
@@ -96,8 +96,7 @@ This ensures that there is an existing Beaver Builder layout for this page. If
 there is no existing Beaver Builder layout, the dot is light gray or white.  
 ![](/img/the-basics-convert-content-4.png)
 
-  3. Click **Edit**.  
-  If you have the Classic Editor installed, then click either **Edit** or **Classic Editor**, depending on your settings in **Settings > Writing**.
+  3. Click either **Edit** or **Classic Editor**, depending on your WordPress settings.
 
  **Result:** The text and images are converted from Beaver Builder to Classic
 Editor.

--- a/docs/beaver-themer/layout-types-modules/singular-layout-type/themer-singular-layout-type.md
+++ b/docs/beaver-themer/layout-types-modules/singular-layout-type/themer-singular-layout-type.md
@@ -66,7 +66,7 @@ This template has the following modules:
     * **Terms**  
     By default the Taxonomy is **Categories**, but you can also choose **Tags**.
 * The [Post Content module](/beaver-themer/layout-types-modules/singular-layout-type/themer-singular-layout-post-content-module.md) contains the post's content.  
-  **Note**: You can't use Beaver Builder to edit the content of individual posts when a Singular Themer layout will apply to that post, because it breaks the Themer layout. You'll use the native WordPress editor for post content (Standard or Classic editor), where you can add text, images, shortcodes, and some types of code.
+  **Note**: You can't use Beaver Builder to edit the content of individual posts when a Singular Themer layout will apply to that post, because it breaks the Themer layout. You'll use the native WordPress editor for post content (Gutenberg or Classic), where you can add text, images, shortcodes, and some types of code.
 * The [HTML module](/beaver-builder/layouts/modules/html.md) is a standard Beaver Builder module. In this template, it contains a field connection shortcode to display the Post terms list, which for standard posts are either categories or tags. The template contains the following string in the HTML module:  
   `Posted in [wpbb post:terms_list taxonomy="category" separator=", "]`  
   There is an additional **Layout** option for the Post Terms List shortcode, which can be used to display the post terms as an unordered or ordered list, rather than a list separated by commas. Note that hierarchical categories are displayed as a flat list. See the [Post Terms List entry in the Themer shortcode reference](/beaver-themer/field-connections/field-connection-shortcode-index-themer.md) for how to code this option.

--- a/docs/beaver-themer/layout-types-modules/singular-layout-type/themer-singular-layout-type.md
+++ b/docs/beaver-themer/layout-types-modules/singular-layout-type/themer-singular-layout-type.md
@@ -66,7 +66,7 @@ This template has the following modules:
     * **Terms**  
     By default the Taxonomy is **Categories**, but you can also choose **Tags**.
 * The [Post Content module](/beaver-themer/layout-types-modules/singular-layout-type/themer-singular-layout-post-content-module.md) contains the post's content.  
-  **Note**: You can't use Beaver Builder to edit the content of individual posts when a Singular Themer layout will apply to that post, because it breaks the Themer layout. You'll use the native WordPress editor for post content (Gutenberg or Classic), where you can add text, images, shortcodes, and some types of code.
+  **Note**: You can't use Beaver Builder to edit the content of individual posts when a Singular Themer layout will apply to that post, because it breaks the Themer layout. You'll use the native WordPress editor for post content (Standard or Classic editor), where you can add text, images, shortcodes, and some types of code.
 * The [HTML module](/beaver-builder/layouts/modules/html.md) is a standard Beaver Builder module. In this template, it contains a field connection shortcode to display the Post terms list, which for standard posts are either categories or tags. The template contains the following string in the HTML module:  
   `Posted in [wpbb post:terms_list taxonomy="category" separator=", "]`  
   There is an additional **Layout** option for the Post Terms List shortcode, which can be used to display the post terms as an unordered or ordered list, rather than a list separated by commas. Note that hierarchical categories are displayed as a flat list. See the [Post Terms List entry in the Themer shortcode reference](/beaver-themer/field-connections/field-connection-shortcode-index-themer.md) for how to code this option.

--- a/docs/general/account-billing/downgrade-to-a-lower-version-of-beaver-builder.md
+++ b/docs/general/account-billing/downgrade-to-a-lower-version-of-beaver-builder.md
@@ -6,7 +6,7 @@ sidebar_label: Downgrade license
 
 This article has information about downgrading from one premium version to
 another or downgrading from a premium version to the free Beaver Builder Lite
-plugin. If you want to stop using Beaver Builder entirely, see [the article about  how to uninstall](/beaver-builder/troubleshooting/updates-license/uninstall-or-deactivate-the-beaver-builder-plugin/#uninstall-beaver-builder-plugin-and-settings.md).
+plugin. If you want to stop using Beaver Builder entirely, see [the article about how to uninstall](/beaver-builder/troubleshooting/updates-license/uninstall-or-deactivate-the-beaver-builder-plugin.md#uninstall-beaver-builder-plugin-and-settings).
 
 :::important **Important**
   * If your premium version is more than 30 days beyond purchase we cannot issue a refund if you choose to downgrade. See our refund policy in [Terms and Conditions](https://www.wpbeaverbuilder.com/terms-and-conditions/).
@@ -67,7 +67,7 @@ If you plan to continue using the Beaver Builder Theme, you don't need to do any
 
 If you downgrade from any premium version to the free Beaver Builder Lite
 plugin, the only modules that will continue to function on the live site and
-in the editor are [the ones contained in the Lite version](/general/pre-sales/difference-between-free-and-premium-versions.md). 
+in the editor are [the ones contained in the Lite version](/general/pre-sales/difference-between-free-and-premium-versions.mdx). 
 
 After you downgrade, what's left on the
 Beaver Beaver Lite editing page is the framework of rows and columns that were

--- a/docs/general/account-billing/downgrade-to-a-lower-version-of-beaver-builder.md
+++ b/docs/general/account-billing/downgrade-to-a-lower-version-of-beaver-builder.md
@@ -28,30 +28,49 @@ No matter which premium version you use, you'll have access to the entire set
 of Beaver Builder plugin rows, columns, and modules, both on the rendered
 pages and in the Beaver Builder editor.
 
-**To downgrade from one premium version to another:**
+### Get and download the downgrade version
 
   1. File a Beaver Builder Support ticket to request a downgrade. Tell us which version you want to downgrade to, and give us identifying information for your subscription, such as your license number or the email address that you used to purchase the subscription. Note that we cannot refund the difference in versions after the first 30 days of a subscription of renewal.
   2. After you're notified of the downgrade, go to your [My Account](https://www.wpbeaverbuilder.com/my-account/) page and download the new version of the plugin from the website.  
+
+:::note **Note**
 If you downgrade from Agency to Pro version, the version of the Beaver Builder
 Theme remains licensed and you don't have to reinstall it. If you downgrade
 from Pro to Standard, the Beaver Builder Theme will continue to work but you
 won't be able to update it, so we encourage you to switch to another theme.
+:::
 
-  3. On the WordPress admin panel, click **Plugins** to display your list of installed plugins.
-  4. Deactivate and delete the Beaver Builder plugin.  
-You won't lose data or layouts or custom CSS when you delete the plugin.
+### Install the downgrade version on your site
 
-  5. On the **Installed plugins** page, click **Add new** and upload, install, and activate the new version of the plugin.
-  6. Go to **Settings > Beaver Builder** and click the **License** tab. Check that your license is still active. If not, copy the license number on your [My Account](https://www.wpbeaverbuilder.com/my-account/) page and enter it on the **License** tab.
+### If you're using WordPress 5.5:
+
+1. Go to the WordPress admin panel for your site and click **Plugins**.
+2. Click the **Add new** button at the top of the page, then **Upload plugin**.
+3. Click **Browse** and select the downloaded plugin zip file on your local system, then click **Install now**.
+3. On the next screen, verify that the zip file you uploaded is the version you want to install, then click **Replace current with uploaded**.
+4. Go to **Settings > Beaver Builder** and click the **License** tab. Check that your license is still active. If not, copy the license number on your [My Account](https://www.wpbeaverbuilder.com/my-account/) page and enter it on the **License** tab.
+5. If you plan to discontinue using the Beaver Builder Theme, install the theme you want to use and switch to it following standard WordPress practice.   
+If you plan to continue using the Beaver Builder Theme, you don't need to do anything.
+
+
+### If you're using a version of WordPress prior to 5.5:
+
+1. Go to the WordPress admin panel for your site and click **Plugins**.
+2. Deactivate and delete your existing Beaver Builder plugin.  
+  Your layouts and page content won’t be lost. You'll get a warning that Beaver Themer won't work without the Beaver Builder plugin, but you can ignore that message.
+3. Upload, install, and activate the new version of the Beaver Builder plugin in the normal manner.
+4. Go to **Settings > Beaver Builder** and click the **License** tab. Check that your license is still active. If not, copy the license number on your [My Account](https://www.wpbeaverbuilder.com/my-account/) page and enter it on the **License** tab.
+5. If you plan to discontinue using the Beaver Builder Theme, install the theme you want to use and switch to it following standard WordPress practice.   
+If you plan to continue using the Beaver Builder Theme, you don't need to do anything.
 
 ## Downgrade from a premium version to the free Beaver Builder Lite plugin
 
 If you downgrade from any premium version to the free Beaver Builder Lite
 plugin, the only modules that will continue to function on the live site and
-in the editor are the ones contained in the Lite version. What's left on the
-Beaver Beaver Lite editing page is the framework of rows and columns that were
-previously there and any modules that are still supported.
+in the editor are [the ones contained in the Lite version](/general/pre-sales/difference-between-free-and-premium-versions.md). 
 
-See the [Beaver Builder Lite plugin page](https://wordpress.org/plugins/beaver-builder-lite-version/) for a list of modules supported by the free version. If you open the page in the WordPress editor, you can see any text and image portions of the
-modules that could be converted. Modules such as the Posts module will not be
-converted to the WordPress editor.
+After you downgrade, what's left on the
+Beaver Beaver Lite editing page is the framework of rows and columns that were
+previously there and any modules that are still supported. If you open the page in the WordPress editor, you can see any text and image portions of the
+modules that could be converted. 
+

--- a/docs/general/account-billing/downgrade-to-a-lower-version-of-beaver-builder.md
+++ b/docs/general/account-billing/downgrade-to-a-lower-version-of-beaver-builder.md
@@ -71,6 +71,5 @@ in the editor are [the ones contained in the Lite version](/general/pre-sales/di
 
 After you downgrade, what's left on the
 Beaver Beaver Lite editing page is the framework of rows and columns that were
-previously there and any modules that are still supported. If you open the page in the WordPress editor, you can see any text and image portions of the
-modules that could be converted. 
+previously there and any modules that are still supported. If you open the page in the WordPress editor, you can see any text and image portions of the modules that could be converted. 
 

--- a/docs/general/account-billing/upgrade-your-premium-license.md
+++ b/docs/general/account-billing/upgrade-your-premium-license.md
@@ -29,7 +29,6 @@ Here are the steps to purchase and install your premium upgrade.
   2. Click the upgrade package that you want.  
 Only eligible upgrades are shown in this section. If you already have the
 Agency version, you won't see any upgrade options.
-
   3.  Complete the checkout process.  
 Your license number remains the same but is now associated with the upgrade
 version.
@@ -37,31 +36,32 @@ version.
 ## 2. Download the upgrade version files
 
   1. From your [My Account](https://www.wpbeaverbuilder.com/my-account/) page, download the Beaver Builder plugin for the upgrade version.
-  2. If you upgraded from the Standard version to Pro or Agency and plan to use the Beaver Builder Theme with the Pro and Agency license, download the Theme and the child theme.
-
+  2. If you upgraded from the Standard version to Pro or Agency and plan to use the Beaver Builder Theme with the Pro and Agency license, download the Theme and the child theme.  
   If you upgraded from Pro to Agency, the theme remains the same and no action is required.
-
   3. If you have already purchased and installed Beaver Themer, you don't need to download it again.
 
 ## 3. Install the Beaver Beaver plugin and theme on your site
 
+**If you're using WordPress 5.5:**
+
+1. Go to the WordPress admin panel for your site and click **Plugins**.
+2. Click the **Add new** button at the top of the page, then **Upload plugin**.
+3. Click **Browse** and select the downloaded plugin zip file on your local system, then click **Install now**.
+3. On the next screen, verify that the zip file you uploaded is the version you want to install, then click **Replace current with uploaded**.
+4. If you're going to start using the Beaver Builder Theme, [follow these instructions](/bb-theme/getting-started/install-the-bb-theme-and-child-theme.md) to install it and the child theme.  
+If you're already using the Beaver Builder Theme you don't need to do anything.
+
+**If you're using a version of WordPress prior to 5.5:**
+
   1. Go to the WordPress admin panel for your site and click **Plugins**.
-  2. Deactivate and delete your existing Beaver Builder plugin.
-
+  2. Deactivate and delete your existing Beaver Builder plugin.  
   Your layouts and page content won’t be lost. You'll get a warning that Beaver Themer won't work without the Beaver Builder plugin, but you can ignore that message.
-
   3. Upload, install, and activate the new version of the Beaver Builder plugin in the normal manner.
-  4. If you're going to start using the Beaver Builder Theme, [follow these instructions](/bb-theme/getting-started/install-the-bb-theme-and-child-theme.md) to install it and the child theme.
-
+  4. If you're going to start using the Beaver Builder Theme, [follow these instructions](/bb-theme/getting-started/install-the-bb-theme-and-child-theme.md) to install it and the child theme.  
   If you're already using the Beaver Builder Theme you don't need to do anything.
 
 :::important **Info**
 If you don't install the upgraded version immediately, your previous
 premium version of the plugin will continue to notify you of updates on the
 WordPress **Plugins** menu.
-
-For example, if you upgrade from a Standard to a
-Pro license, your standard version of the Beaver Builder plugin will continue
-to update. If you upgrade to Agency, both Standard and Pro versions will
-continue to update.
 :::

--- a/docs/general/faq/is-beaver-builder-compatible-with-gutenberg.md
+++ b/docs/general/faq/is-beaver-builder-compatible-with-gutenberg.md
@@ -5,29 +5,29 @@ sidebar_label: Is Beaver Builder compatible with Gutenberg?
 ---
 
 Probably everyone has heard of Gutenberg. It's the project name for
-[the WordPress block editor](https://wordpress.org/gutenberg/) that shipped with WordPress 5. It's also known as the block editor.
+[the WordPress editor](https://wordpress.org/gutenberg/) that shipped with WordPress 5. It's also known as the block editor.
 
 The Beaver Builder plugin is compatible with the WordPress 5 block editor
 in the same way that it's compatible with the "classic" WordPress text editor.
 Depending on whether you set WordPress to prefer the block editor or use a plugin to maintain the
 classic editor, you can move text and images between Beaver Builder and the WordPress editor on a limited scale.
 
-See [the detailed article about how Beaver Builder works with the WordPress Standard (block) editor](/beaver-builder/management-migration/convert-content-between-wordpress-5-and-beaver-builder.md).
+For more details see [the detailed article about how Beaver Builder works with Gutenberg](/beaver-builder/management-migration/convert-content-between-wordpress-5-and-beaver-builder.md).
 
 :::caution Tip:
 The responsive default heading and text styles that you can assign at
 **Customize > General > Headings** and **Customize > General > Text** in the
 Beaver Builder Theme apply as default settings in Beaver Builder and Beaver
 Themer layouts, but they also apply as default settings to headings and text
-in WordPress block  layouts, though they will not display until you preview or view
+in Gutenberg layouts, though they will not display until you preview or view
 the page.
 :::
 
-We think Beaver Builder is far superior to the features that the WorPress Standard Editor offers,
-but we encourage you to try both the Standard Editor and Beaver Builder for yourself. If you
+We think Beaver Builder is far superior to the features that Gutenberg offers,
+but we encourage you to try Gutenberg and Beaver Builder for yourself. If you
 have a Beaver Builder license, you can download the current version of Beaver
 Builder from the [My Account](https://www.wpbeaverbuilder.com/my-account/)
-page, or you can install the free Beaver Builder Lite plugin, or you can try the [Page Builder Demo](http://demo.wpbeaverbuilder.com).
+page, or you can install the free Beaver Builder Lite plugin.
 
 Once you try both page builders side by side, we'd value your feedback on your
 experience. The best mechanism to get feedback directly to us is to [submit a Support ticket](https://www.wpbeaverbuilder.com/beaver-builder-support/).

--- a/docs/general/faq/is-beaver-builder-compatible-with-gutenberg.md
+++ b/docs/general/faq/is-beaver-builder-compatible-with-gutenberg.md
@@ -5,29 +5,29 @@ sidebar_label: Is Beaver Builder compatible with Gutenberg?
 ---
 
 Probably everyone has heard of Gutenberg. It's the project name for
-[the WordPress editor](https://wordpress.org/gutenberg/) that shipped with WordPress 5. It's also known as the block editor.
+[the WordPress block editor](https://wordpress.org/gutenberg/) that shipped with WordPress 5. It's also known as the block editor.
 
 The Beaver Builder plugin is compatible with the WordPress 5 block editor
 in the same way that it's compatible with the "classic" WordPress text editor.
 Depending on whether you set WordPress to prefer the block editor or use a plugin to maintain the
 classic editor, you can move text and images between Beaver Builder and the WordPress editor on a limited scale.
 
-For more details see [the detailed article about how Beaver Builder works with Gutenberg](/beaver-builder/management-migration/convert-content-between-wordpress-5-and-beaver-builder.md).
+See [the detailed article about how Beaver Builder works with the WordPress Standard (block) editor](/beaver-builder/management-migration/convert-content-between-wordpress-5-and-beaver-builder.md).
 
 :::caution Tip:
 The responsive default heading and text styles that you can assign at
 **Customize > General > Headings** and **Customize > General > Text** in the
 Beaver Builder Theme apply as default settings in Beaver Builder and Beaver
 Themer layouts, but they also apply as default settings to headings and text
-in Gutenberg layouts, though they will not display until you preview or view
+in WordPress block  layouts, though they will not display until you preview or view
 the page.
 :::
 
-We think Beaver Builder is far superior to the features that Gutenberg offers,
-but we encourage you to try Gutenberg and Beaver Builder for yourself. If you
+We think Beaver Builder is far superior to the features that the WorPress Standard Editor offers,
+but we encourage you to try both the Standard Editor and Beaver Builder for yourself. If you
 have a Beaver Builder license, you can download the current version of Beaver
 Builder from the [My Account](https://www.wpbeaverbuilder.com/my-account/)
-page, or you can install the free Beaver Builder Lite plugin.
+page, or you can install the free Beaver Builder Lite plugin, or you can try the [Page Builder Demo](http://demo.wpbeaverbuilder.com).
 
 Once you try both page builders side by side, we'd value your feedback on your
 experience. The best mechanism to get feedback directly to us is to [submit a Support ticket](https://www.wpbeaverbuilder.com/beaver-builder-support/).

--- a/docs/general/pre-sales/upgrade-from-free-to-premium-version-of-beaver-buidler.md
+++ b/docs/general/pre-sales/upgrade-from-free-to-premium-version-of-beaver-buidler.md
@@ -11,13 +11,13 @@ keep your content intact.
 Wondering which devices support Beaver Builder? Check out the [system requirements](/beaver-builder/getting-started/system-requirements.md).
 :::
 
-  1. Purchase the premium version, go to your [My Account](https://www.wpbeaverbuilder.com/my-account/) page, and download the Beaver Builder plugin. It will be a zip file
+  1. Purchase the premium version, go to your [My Account](https://www.wpbeaverbuilder.com/my-account/) page, and download the Beaver Builder plugin zip file.  
 Your license key is listed on the same page.
-
   2. On the WordPress **Plugins > Add New** page, click **Upload plugin**.
   3. Select the plugin zip file that you downloaded, install it, and activate it.  
+The Lite version of the plugin is automatically deactivated when you install a premium version.
 **Tip:** Be careful not to mix up the plugin and theme zip files when you
-upload!
-
-  4. On the **Plugins** page, delete the Lite version plugin, which was automatically deactivated.
-  5. Go to **Settings > Beaver Builder **and enter your license key so you can receive plugin updates automatically.
+upload! If your premium version includes the Beaver Builder Theme, see [these instructions](/bb-theme/getting-started/install-the-bb-theme-and-child-theme.md) for how to install it.
+  4. From the WordPress admin panel, go to **Plugins > All plugins**, then delete the Lite version of plugin.
+  5. From the WordPress admin panel, go to **Settings > Beaver Builder **and enter your license key so you can receive plugin updates automatically.  
+  Your license key is available on your [My Account](https://www.wpbeaverbuilder.com/my-account/) page.


### PR DESCRIPTION
Reviewed instances of "Gutenberg" and "WordPress 5" to use more current terminology--Standard Editor or Block editor. Reviewed procedures to open BB or convert to BB to make sure they are still current in WP 5.5. 
Unrelated: Added a link from theme install article to the Pricing page.
Note that commit message about adding a link to theme install includes other changed files related to Gberg. 